### PR TITLE
Update infer_image.py to fix 2 mistakes

### DIFF
--- a/infer/infer_image.py
+++ b/infer/infer_image.py
@@ -58,7 +58,7 @@ for k, filename in enumerate(filenames):
     print(f'Progress {k+1}/{len(filenames)}: {filename}')
     
     raw_frame = cv2.imread(filename)
-    frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    frame = cv2.cvtColor(raw_frame, cv2.COLOR_RGB2BGR)
     frame_height, frame_width = frame.shape[:2]
     
     curr_area = frame_width * frame_height
@@ -106,4 +106,4 @@ for k, filename in enumerate(filenames):
         split_region = np.ones((frame_height, margin_width, 3), dtype=np.uint8) * 255
         combined_frame = cv2.hconcat([raw_frame, split_region, depth])
         combined_frame = combined_frame[height_adjustment:, width_adjustment:]
-        cv2.imwrite(combined_frame, depth)
+        cv2.imwrite(output_path, combined_frame)


### PR DESCRIPTION
I ran your inference pipeline successfully after fixing the following two bugs. 

**Line 61**
```
# Change this
raw_frame = cv2.imread(filename)
frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)

# To this
raw_frame = cv2.imread(filename)
frame = cv2.cvtColor(raw_frame, cv2.COLOR_RGB2BGR)
```

**Line 109**
```
# Change this line:
cv2.imwrite(combined_frame, depth)

# To this:
cv2.imwrite(output_path, combined_frame)
```

**Fixes:** 
```
cv2.imwrite(combined_frame, depth)
cv2.error: OpenCV(4.11.0) :-1: error: (-5:Bad argument) in function 'imwrite'
> Overload resolution failed:
>  - Expected 'filename' to be a str or path-like object
>  - Expected 'filename' to be a str or path-like object
```